### PR TITLE
Add unit tests with jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,29 @@
             <artifactId>mongodb-driver-sync</artifactId>
             <version>5.2.1</version> <!-- Must match your core + bson versions -->
         </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-core</artifactId>
+            <version>9.3.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-core-junit5</artifactId>
+            <version>9.3.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -169,6 +192,40 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/test/java/com/vaadin/demo/AIConfigTest.java
+++ b/src/test/java/com/vaadin/demo/AIConfigTest.java
@@ -1,0 +1,41 @@
+import com.mongodb.client.MongoClient;
+import com.vaadin.demo.AIConfig;
+import com.vaadin.demo.config.AIDocsProperties;
+import com.vaadin.demo.config.MongoDbProperties;
+import dev.langchain4j.memory.chat.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.mockito.Mockito;
+
+class AIConfigTest {
+    @Test
+    void beansCreated() {
+        AIDocsProperties props = new AIDocsProperties();
+        AIDocsProperties.LangChain4j lc = new AIDocsProperties.LangChain4j();
+        AIDocsProperties.LangChain4j.OpenAI open = new AIDocsProperties.LangChain4j.OpenAI();
+        open.setBaseUrl("http://host");
+        open.setModelName("model");
+        open.setEmbeddingModelName("embed");
+        lc.setOpenAi(open);
+        props.setLangchain4j(lc);
+
+        MongoDbProperties mongo = new MongoDbProperties();
+        mongo.setUri("mongodb://localhost");
+        mongo.setDatabase("db");
+        mongo.setCollection("coll");
+
+        AIConfig config = new AIConfig(props, mongo);
+        MongoClient client = config.mongoClient();
+        assertNotNull(client);
+        EmbeddingModel embeddingModel = config.embeddingModel();
+        assertNotNull(embeddingModel);
+        ChatMemoryProvider provider = config.chatMemoryProvider();
+        ChatMemory memory = provider.get("id");
+        assertNotNull(memory);
+        StreamingChatLanguageModel model = config.streamingChatLanguageModel();
+        assertNotNull(model);
+    }
+}

--- a/src/test/java/com/vaadin/demo/ApplicationTest.java
+++ b/src/test/java/com/vaadin/demo/ApplicationTest.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTest {
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/vaadin/demo/config/AIDocsPropertiesTest.java
+++ b/src/test/java/com/vaadin/demo/config/AIDocsPropertiesTest.java
@@ -1,0 +1,29 @@
+import com.vaadin.demo.config.AIDocsProperties;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AIDocsPropertiesTest {
+    @Test
+    void gettersAndSettersWork() {
+        AIDocsProperties props = new AIDocsProperties();
+        props.setLocation("loc");
+        AIDocsProperties.LangChain4j lc = new AIDocsProperties.LangChain4j();
+        AIDocsProperties.LangChain4j.OpenAI open = new AIDocsProperties.LangChain4j.OpenAI();
+        open.setApiKey("key");
+        open.setBaseUrl("url");
+        open.setModelName("model");
+        open.setEmbeddingModelName("embed");
+        open.setBaseUrlChat("chatUrl");
+        lc.setOpenAi(open);
+        props.setLangchain4j(lc);
+
+        assertEquals("loc", props.getLocation());
+        assertEquals(lc, props.getLangchain4j());
+        assertEquals(open, props.getLangchain4j().getOpenAi());
+        assertEquals("key", open.getApiKey());
+        assertEquals("url", open.getBaseUrl());
+        assertEquals("model", open.getModelName());
+        assertEquals("embed", open.getEmbeddingModelName());
+        assertEquals("chatUrl", open.getBaseUrlChat());
+    }
+}

--- a/src/test/java/com/vaadin/demo/config/MongoDbPropertiesTest.java
+++ b/src/test/java/com/vaadin/demo/config/MongoDbPropertiesTest.java
@@ -1,0 +1,19 @@
+import com.vaadin.demo.config.MongoDbProperties;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MongoDbPropertiesTest {
+    @Test
+    void gettersAndSettersWork() {
+        MongoDbProperties props = new MongoDbProperties();
+        props.setUri("uri");
+        props.setDatabase("db");
+        props.setCollection("col");
+        props.setIndexName("idx");
+
+        assertEquals("uri", props.getUri());
+        assertEquals("db", props.getDatabase());
+        assertEquals("col", props.getCollection());
+        assertEquals("idx", props.getIndexName());
+    }
+}

--- a/src/test/java/com/vaadin/demo/views/AboutViewTest.java
+++ b/src/test/java/com/vaadin/demo/views/AboutViewTest.java
@@ -1,0 +1,13 @@
+import com.vaadin.demo.views.AboutView;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.testbench.TestBenchTestCase;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AboutViewTest extends TestBenchTestCase {
+    @Test
+    void containsHeader() {
+        AboutView view = new AboutView();
+        assertTrue(view.getComponentAt(0) instanceof H1);
+    }
+}

--- a/src/test/java/com/vaadin/demo/views/ChatViewTest.java
+++ b/src/test/java/com/vaadin/demo/views/ChatViewTest.java
@@ -1,0 +1,24 @@
+import com.vaadin.demo.AiAssistant;
+import com.vaadin.demo.views.ChatView;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.messages.MessageInput;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.testbench.TestBenchTestCase;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.mockito.Mockito;
+
+class ChatViewTest extends TestBenchTestCase {
+    @Test
+    void componentsCreated() {
+        AiAssistant assistant = Mockito.mock(AiAssistant.class);
+        ChatView view = new ChatView(assistant);
+        UI ui = new UI();
+        ui.add(view);
+
+        assertEquals(3, view.getComponentCount());
+        assertTrue(view.getComponentAt(0) instanceof Button);
+        assertTrue(view.getComponentAt(2) instanceof MessageInput);
+    }
+}

--- a/src/test/java/com/vaadin/demo/views/MainLayoutTest.java
+++ b/src/test/java/com/vaadin/demo/views/MainLayoutTest.java
@@ -1,0 +1,17 @@
+import com.vaadin.demo.views.MainLayout;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.applayout.AppLayout;
+import com.vaadin.flow.component.sidenav.SideNav;
+import com.vaadin.testbench.TestBenchTestCase;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MainLayoutTest extends TestBenchTestCase {
+    @Test
+    void navigationCreated() {
+        MainLayout layout = new MainLayout();
+        UI ui = new UI();
+        ui.add(layout);
+        assertTrue(layout.getContent() instanceof SideNav || layout.getChildren().anyMatch(c -> c instanceof SideNav));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for configuration and views
- configure test dependencies and jacoco plugin
- create basic Spring context loading test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68412361700883339961d86a2273b921